### PR TITLE
fix(cli): update default min-peers to 5 to match documentation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ const (
 	// DefaultDiscoveryInterval is the default discovery interval
 	DefaultDiscoveryInterval = 10 * time.Second
 	// DefaultMinPeers is the default minimum number of peers
-	DefaultMinPeers = 0
+	DefaultMinPeers = 5
 	// DefaultMaxPeers is the default maximum number of peers
 	DefaultMaxPeers = 50
 


### PR DESCRIPTION
fix(cli): update default min-peers to 5 to match documentation

The --min-peers flag was documented to have a default value of 5, but the code had it set to 0. This commit changes the default value in the code to 5, aligning with the documentation and improving user experience.

## Changes

- Updated the default value of `--min-peers` to 5 in the code.

## Tests

To verify the changes, run the following integration tests:

```sh
go test -tags integration github.com/ChainSafe/gossamer

## Issues
#4252